### PR TITLE
Handle situation where prompt is in output

### DIFF
--- a/acl2_kernel/kernel.py
+++ b/acl2_kernel/kernel.py
@@ -1,5 +1,5 @@
 from ipykernel.kernelbase import Kernel
-from pexpect import replwrap, EOF
+from pexpect import replwrap, EOF, TIMEOUT
 import pexpect
 
 from subprocess import PIPE, Popen
@@ -53,6 +53,12 @@ class ACL2Kernel(Kernel):
         try:
             cmd = re.sub(r'[\r\n]|;[^\r\n]*[\r\n]+', ' ', code.strip())
             output = self.acl2wrapper.run_command(cmd, timeout=None)
+            while True:
+                try:
+                    more_output = self.acl2wrapper.run_command(';', timeout=0)
+                except TIMEOUT:
+                    break
+                output += more_output
         except KeyboardInterrupt:
             self.acl2wrapper.child.sendintr()
             interrupted = True


### PR DESCRIPTION
This pr is a fix for situations where the ACL2 prompt is in the output. For example, the second form in the following ACL2 block:

```lisp
(include-book "acl2s/cgen/top" :dir :system :ttags :all)
(acl2s-defaults :set testing-enabled t)
```

has the following output:

```lisp


ACL2 !>>(ACL2S::ENABLE-ACL2S-RANDOM-TESTING)


ACL2 !>>(ACL2S::DISABLE-ACL2S-RANDOM-TESTING)


ACL2 !>>(REMOVE-OVERRIDE-HINTS!
         '((LIST*
            :BACKTRACK
            (CONS
             'TEST-CHECKPOINT
             (CONS
              'ID
              (CONS
                'CLAUSE
                (CONS 'CLAUSE-LIST
                      (CONS 'PROCESSOR
                            (CONS (CONS 'QUOTE (CONS PSPV 'NIL))
                                  (CONS (CONS 'QUOTE (CONS HIST 'NIL))
                                        (CONS 'CTX (CONS 'STATE 'NIL)))))))))
            KEYWORD-ALIST)))

The event ( TABLE DEFAULT-HINTS-TABLE ...) is redundant.  See :DOC
redundant-events.


ACL2 !>>(ADD-OVERRIDE-HINTS!
         '((LIST*
            :BACKTRACK
            (CONS
             'TEST-CHECKPOINT
             (CONS
              'ID
              (CONS
                'CLAUSE
                (CONS 'CLAUSE-LIST
                      (CONS 'PROCESSOR
                            (CONS (CONS 'QUOTE (CONS PSPV 'NIL))
                                  (CONS (CONS 'QUOTE (CONS HIST 'NIL))
                                        (CONS 'CTX (CONS 'STATE 'NIL)))))))))
            KEYWORD-ALIST)))


ACL2 !>>(TABLE ACL2S-DEFAULTS-TABLE ':TESTING-ENABLED
               '(ACL2S::ACL2S-PARAM-INFO%
                     T
                     (MEMBER-EQ VALUE ACL2S::*TESTING-ENABLED-VALUES*)
                     ACL2S::SET-ACL2S-RANDOM-TESTING-ENABLED))
 ACL2S-DEFAULTS-TABLE
```

This pr ensure that the kernel reads the whole output and not get hung up on the first `ACL2 !>` prompt.