### PR TITLE
Support multiple top-level forms in a code block

### DIFF
--- a/acl2_kernel/kernel.py
+++ b/acl2_kernel/kernel.py
@@ -1,6 +1,7 @@
 from ipykernel.kernelbase import Kernel
 from pexpect import replwrap, EOF, TIMEOUT
 import pexpect
+import regex
 
 from subprocess import PIPE, Popen
 import signal
@@ -51,8 +52,11 @@ class ACL2Kernel(Kernel):
             }
         interrupted = False
         try:
+            num_cmds = len(regex.findall(r'^[ \t]*:.*$|\((?>[^()]|(?R))*\)', code, regex.MULTILINE))
             cmd = re.sub(r'[\r\n]|;[^\r\n]*[\r\n]+', ' ', code.strip())
             output = self.acl2wrapper.run_command(cmd, timeout=None)
+            for i in range(num_cmds - 1):
+                output += self.acl2wrapper.run_command(';', timeout=None)
             while True:
                 try:
                     more_output = self.acl2wrapper.run_command(';', timeout=0)

--- a/acl2_kernel/kernel.py
+++ b/acl2_kernel/kernel.py
@@ -52,8 +52,9 @@ class ACL2Kernel(Kernel):
             }
         interrupted = False
         try:
-            num_cmds = len(regex.findall(r'^[ \t]*:.*$|\((?>[^()]|(?R))*\)', code, regex.MULTILINE))
-            cmd = re.sub(r'[\r\n]|;[^\r\n]*[\r\n]+', ' ', code.strip())
+            cmd = re.sub(r';.*$', '', code, flags=re.MULTILINE)
+            num_cmds = len(regex.findall(r'^[ \t]*:.*$|\((?>[^()]|(?R))*\)', cmd, regex.MULTILINE))
+            cmd = re.sub(r'[\r\n]', ' ', cmd.strip())
             output = self.acl2wrapper.run_command(cmd, timeout=None)
             for i in range(num_cmds - 1):
                 output += self.acl2wrapper.run_command(';', timeout=None)

--- a/acl2_kernel/kernel.py
+++ b/acl2_kernel/kernel.py
@@ -52,9 +52,27 @@ class ACL2Kernel(Kernel):
             }
         interrupted = False
         try:
+            # Remove all comments from the code block.
             cmd = re.sub(r';.*$', '', code, flags=re.MULTILINE)
+
+            # Count all commands in the code block. There are 2 types of
+            # commands recognized:
+            #
+            # 1. Keyword commands, such as:
+            #      :pl subsetp
+            #    using the ^[ \t]*:.*$ regex. This is a simple recognizer that
+            #    treats the whole line as the keyword command.
+            # 2. Top-level LISP forms, such as:
+            #      (defun app (x y)
+            #        (cond ((endp x) y)
+            #              (t (cons (car x)
+            #                       (app (cdr x) y)))))
+            #    using the \((?>[^()]|(?R))*\) regex.
             num_cmds = len(regex.findall(r'^[ \t]*:.*$|\((?>[^()]|(?R))*\)', cmd, regex.MULTILINE))
+
+            # Convert all \r and \n into spaces.
             cmd = re.sub(r'[\r\n]', ' ', cmd.strip())
+
             output = self.acl2wrapper.run_command(cmd, timeout=None)
             for i in range(num_cmds - 1):
                 output += self.acl2wrapper.run_command(';', timeout=None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ pexpect = "^4.8.0"
 ipykernel = "^5.3.0"
 jupyter_client = "^6.1.3"
 ipython = "^7.15.0"
+regex = "^2021.4.4"
 
 [tool.poetry.dev-dependencies]
 jupyter = "^1.0.0"


### PR DESCRIPTION
This pr adds proper kernel support for multiple top-level forms in a code block, e.g.:

```lisp
(@ acl2-version)
:set-gag-mode nil
(include-book "std/util/define" :dir :system)
(include-book "std/util/defrule" :dir :system)
```

A couple of caveats:

1. The regular expression is ugly and is not even regular.
2. The keyword command recognizer is simple and does not fully follow the [Keyword-commands specification](https://www.cs.utexas.edu/users/moore/acl2/v8-3/combined-manual/index.html?topic=ACL2____KEYWORD-COMMANDS). Following the spec fully would require querying ACL2 though.

That said, this solution requires very few lines of code.