### PR TITLE
Support normally-prompt-changing commands by freezing the ACL2 prompt

### DIFF
--- a/acl2_kernel/kernel.py
+++ b/acl2_kernel/kernel.py
@@ -39,14 +39,14 @@ class ACL2Kernel(Kernel):
         sig = signal.signal(signal.SIGINT, signal.SIG_DFL)
         try:
             prompt_change_cmd = '''
-(progn
-  (set-state-ok t)
-  (defun jupyter-prompt (channel state)
-    (declare (xargs :mode :program))
-    (fmt1 "JPY-ACL2>" '() 0 channel state nil))
-  (set-state-ok nil))
-(set-ld-prompt 'jupyter-prompt state)
-(reset-prehistory)'''
+                    (progn
+                      (set-state-ok t)
+                      (defun jupyter-prompt (channel state)
+                        (declare (xargs :mode :program))
+                        (fmt1 "JPY-ACL2>" '() 0 channel state nil))
+                      (set-state-ok nil))
+                    (set-ld-prompt 'jupyter-prompt state)
+                    (reset-prehistory)'''
             self.acl2wrapper = replwrap.REPLWrapper(os.environ['ACL2'], 'ACL2 !>', prompt_change_cmd, 'JPY-ACL2>')
             self.acl2wrapper.run_command(';', timeout=None) # This discards the output of progn.
             self.acl2wrapper.run_command(';', timeout=None) # This discards the output of reset-prehistory.

--- a/acl2_kernel/kernel.py
+++ b/acl2_kernel/kernel.py
@@ -38,7 +38,18 @@ class ACL2Kernel(Kernel):
     def _start_acl2(self):
         sig = signal.signal(signal.SIGINT, signal.SIG_DFL)
         try:
-            self.acl2wrapper = replwrap.REPLWrapper(os.environ['ACL2'], 'ACL2 !>', None)
+            prompt_change_cmd = '''
+(progn
+  (set-state-ok t)
+  (defun jupyter-prompt (channel state)
+    (declare (xargs :mode :program))
+    (fmt1 "JPY-ACL2>" '() 0 channel state nil))
+  (set-state-ok nil))
+(set-ld-prompt 'jupyter-prompt state)
+(reset-prehistory)'''
+            self.acl2wrapper = replwrap.REPLWrapper(os.environ['ACL2'], 'ACL2 !>', prompt_change_cmd, 'JPY-ACL2>')
+            self.acl2wrapper.run_command(';', timeout=None) # This discards the output of progn.
+            self.acl2wrapper.run_command(';', timeout=None) # This discards the output of reset-prehistory.
         finally:
             signal.signal(signal.SIGINT, sig)
         


### PR DESCRIPTION
This pr prevents the kernel from hanging on commands that normally change the ACL2 prompt such as

```lisp
:set-guard-checking :none
```

by making the prompt invariant.