### PR TITLE
Define jupyter-prompt in an encapsulate form

### DIFF
--- a/acl2_kernel/kernel.py
+++ b/acl2_kernel/kernel.py
@@ -39,12 +39,11 @@ class ACL2Kernel(Kernel):
         sig = signal.signal(signal.SIGINT, signal.SIG_DFL)
         try:
             prompt_change_cmd = '''
-                    (progn
+                    (encapsulate ()
                       (set-state-ok t)
                       (defun jupyter-prompt (channel state)
                         (declare (xargs :mode :program))
-                        (fmt1 "JPY-ACL2>" '() 0 channel state nil))
-                      (set-state-ok nil))
+                        (fmt1 "JPY-ACL2>" '() 0 channel state nil)))
                     (set-ld-prompt 'jupyter-prompt state)
                     (reset-prehistory)'''
             self.acl2wrapper = replwrap.REPLWrapper(os.environ['ACL2'], 'ACL2 !>', prompt_change_cmd, 'JPY-ACL2>')


### PR DESCRIPTION
This pr defines `jupyter-prompt` in an `encapsulate` form for 2 reasons:

1. It requires less lines of code.
2. More importantly, the previous value of `state-ok` is restored whether it's `t` or `nil`.