### PR TITLE
Set trust tag for ACL2 8.4

### DIFF
--- a/acl2_kernel/kernel.py
+++ b/acl2_kernel/kernel.py
@@ -44,11 +44,14 @@ class ACL2Kernel(Kernel):
                       (defun jupyter-prompt (channel state)
                         (declare (xargs :mode :program))
                         (fmt1 "JPY-ACL2>" '() 0 channel state nil)))
+                    (defttag t)
                     (set-ld-prompt 'jupyter-prompt state)
+                    (defttag nil)
                     (reset-prehistory)'''
             self.acl2wrapper = replwrap.REPLWrapper(os.environ['ACL2'], 'ACL2 !>', prompt_change_cmd, 'JPY-ACL2>')
-            self.acl2wrapper.run_command(';', timeout=None) # This discards the output of progn.
-            self.acl2wrapper.run_command(';', timeout=None) # This discards the output of reset-prehistory.
+            # Discard the output of prompt_change_cmd.
+            for i in range(3):
+                self.acl2wrapper.run_command(';', timeout=None)
         finally:
             signal.signal(signal.SIGINT, sig)
         


### PR DESCRIPTION
This pr fixes acl2-kernel so that it works with ACL2 8.4, by setting a trust tag as noted in https://www.cs.utexas.edu/users/moore/acl2/v8-4/combined-manual/index.html?topic=ACL2____NOTE-8-4 (search for `ld-prompt`).

The fix works with both ACL2 8.3 and 8.4.